### PR TITLE
Add README link check test and CI workflow

### DIFF
--- a/.github/workflows/readme-link-test.yml
+++ b/.github/workflows/readme-link-test.yml
@@ -1,0 +1,19 @@
+name: Readme link check
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest requests
+      - name: Run tests
+        run: pytest tests/test_readme_links.py

--- a/tests/test_readme_links.py
+++ b/tests/test_readme_links.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import re
+import requests
+
+
+def extract_links(content: str) -> list[str]:
+    """Return list of URLs from href and src attributes."""
+    hrefs = re.findall(r'href="([^"]+)"', content)
+    srcs = re.findall(r'src="([^"]+)"', content)
+    return hrefs + srcs
+
+
+def fetch_status(url: str) -> int:
+    """Fetch URL returning HTTP status code."""
+    for method in ("head", "get"):
+        try:
+            resp = requests.request(method, url, allow_redirects=True, timeout=10)
+            return resp.status_code
+        except requests.RequestException:
+            if method == "get":
+                raise
+            continue
+    raise AssertionError(f"Unable to fetch {url}")
+
+
+def test_readme_links():
+    content = Path("README.md").read_text(encoding="utf-8")
+    links = extract_links(content)
+    assert links, "No links found in README.md"
+    for url in links:
+        status = fetch_status(url)
+        assert status < 400, f"{url} returned status {status}"


### PR DESCRIPTION
## Summary
- add pytest verifying all README links respond with HTTP status <400
- run the link check in CI on pull requests

## Testing
- `pytest tests/test_readme_links.py` *(fails: ProxyError for thangs.com)*

------
https://chatgpt.com/codex/tasks/task_e_689b48f891908326ab9be8c0e437d3d7